### PR TITLE
Environment Variable Configuration Changes

### DIFF
--- a/helper/properties.go
+++ b/helper/properties.go
@@ -46,7 +46,7 @@ func (p Properties) Execute() (map[string]string, error) {
 		s = strings.ReplaceAll(s, "-", "_")
 		s = strings.ReplaceAll(s, ".", "_")
 
-		e[fmt.Sprintf("APPINSIGHTS_%s", s)] = v
+		e[fmt.Sprintf("APPLICATIONINSIGHTS_%s", s)] = v
 	}
 
 	return e, nil

--- a/helper/properties_test.go
+++ b/helper/properties_test.go
@@ -42,10 +42,10 @@ func testProperties(t *testing.T, context spec.G, it spec.S) {
 			{
 				Name:   "test-binding",
 				Type:   "ApplicationInsights",
-				Secret: map[string]string{"InstrumentationKey": "test-value"},
+				Secret: map[string]string{"connection-string": "test-value"},
 			},
 		}
 
-		Expect(p.Execute()).To(Equal(map[string]string{"APPINSIGHTS_INSTRUMENTATIONKEY": "test-value"}))
+		Expect(p.Execute()).To(Equal(map[string]string{"APPLICATIONINSIGHTS_CONNECTION_STRING": "test-value"}))
 	})
 }


### PR DESCRIPTION
Previously, the library prefixed all of its configuration variables with `APPINSIGHTS_`.  A recent release changed that so that they all now start with `APPLICATION_INSIGHTS`.  This change updates the buildpack to take that into account.

see: https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config
