### PR TITLE
Buildpack metadata updates

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.5"
+api = "0.6"
 
 [buildpack]
-id       = "paketo-buildpacks/azure-application-insights"
-name     = "Paketo Azure Application Insights Buildpack"
-version  = "{{.version}}"
-homepage = "https://github.com/paketo-buildpacks/azure-application-insights"
+id          = "paketo-buildpacks/azure-application-insights"
+name        = "Paketo Azure Application Insights Buildpack"
+version     = "{{.version}}"
+homepage    = "https://github.com/paketo-buildpacks/azure-application-insights"
+description = "A Cloud Native Buildpack that contributes the Application Insights Agent and configures it to connect to the service"
+keywords    = ["java", "nodejs", "azure", "application-insights"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri  = "https://github.com/paketo-buildpacks/azure-application-insights/blob/main/LICENSE"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,8 +5,13 @@ set -euo pipefail
 GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/azure-application-insights/cmd/helper
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/azure-application-insights/cmd/main
 
-strip bin/helper bin/main
-upx -q -9 bin/helper bin/main
+if [ "${STRIP:-false}" != "false" ]; then
+  strip bin/helper bin/main
+fi
+
+if [ "${COMPRESS:-false}" != "false" ]; then
+  upx -q -9 bin/helper bin/main
+fi
 
 ln -fs main bin/build
 ln -fs main bin/detect


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Bump the lifecycle to 0.6, add description, keywords and license metadata and make running 'upx' optional, default off in build script

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
