### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/azure-application-insights`
-The Paketo Azure Application Insights Buildpack is a Cloud Native Buildpack that contributes the Application Insights Agent and configures it to connect to the service.
+The Paketo Buildpack for Azure Application Insights is a Cloud Native Buildpack that contributes the Application Insights Agent and configures it to connect to the service.
 
 ## Behavior
 This buildpack will participate if all the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/azure-application-insights"
   id = "paketo-buildpacks/azure-application-insights"
   keywords = ["java", "nodejs", "azure", "application-insights"]
-  name = "Paketo Azure Application Insights Buildpack"
+  name = "Paketo Buildpack for Azure Application Insights"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Azure Application Insights Buildpack' to 'Paketo Buildpack for Azure Application Insights'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
