### PR TITLE
Adds node_modules to node detection criteria

### DIFF
--- a/insights/detect.go
+++ b/insights/detect.go
@@ -51,6 +51,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				Requires: []libcnb.BuildPlanRequire{
 					{Name: "azure-application-insights-nodejs"},
 					{Name: "node", Metadata: map[string]interface{}{"build": true}},
+					{Name: "node_modules"},
 				},
 			},
 		},

--- a/insights/detect_test.go
+++ b/insights/detect_test.go
@@ -62,6 +62,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "azure-application-insights-nodejs"},
 						{Name: "node", Metadata: map[string]interface{}{"build": true}},
+						{Name: "node_modules"},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Changes node detection criteria to include `node_modules` - this ensures node is not provided by the Java buildpack inadvertently.

## Use Cases
Fixes issue similar to  paketo-buildpacks/new-relic#73

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
